### PR TITLE
Move back to BPManager, add extra logging

### DIFF
--- a/ButtplugValley/BPManager.cs
+++ b/ButtplugValley/BPManager.cs
@@ -1,4 +1,4 @@
-﻿using Buttplug.Client;
+using Buttplug.Client;
 using Buttplug.Client.Connectors.WebsocketConnector;
 using System;
 using System.Linq;
@@ -37,6 +37,9 @@ namespace ButtplugValley
             client = new ButtplugClient("ButtplugValley");
             await client.ConnectAsync(new ButtplugWebsocketConnector(new Uri("ws://localhost:12345")));
             client.DeviceAdded += HandleDeviceAdded;
+            client.DeviceRemoved += HandleDeviceRemoved;
+            client.ServerDisconnect += (object o, EventArgs e) => monitor.Log("Intiface Server disconnected.", LogLevel.Warn);
+            monitor.Log("Buttplug Client Connected", LogLevel.Info);
             // Add other event handlers as needed
         }
 
@@ -53,9 +56,14 @@ namespace ButtplugValley
 
         private void HandleDeviceAdded(object sender, DeviceAddedEventArgs e)
         {
-            Console.WriteLine($"Device connected: {e.Device.Name}");
+            monitor.Log($"Buttplug Device {e.Device.Name} ({e.Device.DisplayName} : {e.Device.Index}) Added", LogLevel.Info);
         }
-        
+
+        private void HandleDeviceRemoved(object sender, DeviceRemovedEventArgs e)
+        {
+            monitor.Log($"Buttplug Device {e.Device.Name} ({e.Device.DisplayName} : {e.Device.Index}) Removed", LogLevel.Info);
+        }
+
         private bool HasVibrators()
         {
             return client.Devices.Any(device => device.VibrateAttributes.Count > 0);

--- a/ButtplugValley/BPManager.cs
+++ b/ButtplugValley/BPManager.cs
@@ -66,7 +66,22 @@ namespace ButtplugValley
 
         private bool HasVibrators()
         {
-            return client.Devices.Any(device => device.VibrateAttributes.Count > 0);
+            if (!client.Connected)
+            {
+                // Noop, this ends up being way too spammy if someone is playing with the mod installed but not connected.
+                return false;
+            }
+            else if (client.Devices.Count() == 0)
+            {
+                monitor.Log("Either buttplug is not connected or no devices are available");
+                return false;
+            }
+            else if (!client.Devices.Any(device => device.VibrateAttributes.Count > 0))
+            {
+                monitor.Log("No connected devices have vibrators available.", LogLevel.Warn);
+                return false;
+            }
+            return true;
         }
 
         public async Task VibrateDevice(float level)
@@ -74,7 +89,6 @@ namespace ButtplugValley
             // This implicited works as a Connected check, as Buttplug clears the device list on disconnect.
             if (!HasVibrators())
             {
-                this.monitor.Log("Has vibrators failed", LogLevel.Debug);
                 return;
             }
             float intensity = MathHelper.Clamp(level, 0f, 100f) / 100f;
@@ -99,7 +113,6 @@ namespace ButtplugValley
         {
             if (!HasVibrators())
             {
-                this.monitor.Log("Has vibrators failed", LogLevel.Debug);
                 return;
             }
             float intensity = MathHelper.Clamp(level, 0f, 100f) / 100f;

--- a/ButtplugValley/FishingMinigame.cs
+++ b/ButtplugValley/FishingMinigame.cs
@@ -12,14 +12,14 @@ namespace ButtplugValley
         private IModHelper helper;
         private IReflectionHelper reflectionHelper;
         public float previousCaptureLevel;
-        private OldBPManager _bpManager;
+        private BPManager _bpManager;
         private IMonitor monitor;
         public bool isActive = true;
         
         
         public float maxVibration = 100f; // Adjust as desired
 
-        public FishingMinigame(IModHelper modHelper, IMonitor MeMonitor, OldBPManager MEbpManager)
+        public FishingMinigame(IModHelper modHelper, IMonitor MeMonitor, BPManager MEbpManager)
         {
             helper = modHelper;
             monitor = MeMonitor;

--- a/ButtplugValley/ModEntry.cs
+++ b/ButtplugValley/ModEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
@@ -12,7 +12,7 @@ namespace ButtplugValley
 {
     internal sealed class ModEntry : Mod
     {
-        private OldBPManager buttplugManager;
+        private BPManager buttplugManager;
         private ModConfig Config;
         private FishingMinigame fishingMinigame;
         private bool isVibrating = false;
@@ -21,7 +21,7 @@ namespace ButtplugValley
         public override void Entry(IModHelper helper)
         {
             this.Config = this.Helper.ReadConfig<ModConfig>();
-            buttplugManager = new OldBPManager();
+            buttplugManager = new BPManager();
             fishingMinigame = new FishingMinigame(helper, Monitor, buttplugManager);
             Task.Run(async () =>
             {

--- a/ButtplugValley/ModEntry.cs
+++ b/ButtplugValley/ModEntry.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
@@ -386,7 +386,7 @@ namespace ButtplugValley
             if (e.Button == SButton.P)
             {
                 // Stop Vibrations
-                //Task.Run(async () => await buttplugManager.StopDevices());
+                Task.Run(async () => await buttplugManager.StopDevices());
             }
             if (e.Button == SButton.I)
             {
@@ -403,6 +403,7 @@ namespace ButtplugValley
                 Task.Run(async () =>
                 {
                     await buttplugManager.ConnectButtplug(Monitor);
+                    await buttplugManager.ScanForDevices();
                 });
             }
         }


### PR DESCRIPTION
- Move back to the new BPManager with multi-device support
- Start scanning again when using hotkeys for server reconnect
- Notify via logging whenever devices disconnect or server disconnects
- Log found devices on connection
- Move vibration event logs to trace level (otherwise we spam logs)
