### PR TITLE
Fishing rod use

### DIFF
--- a/ButtplugValley/FishingRod.cs
+++ b/ButtplugValley/FishingRod.cs
@@ -55,6 +55,9 @@ namespace ButtplugValley
 
             }
 
+            /// <summary>
+            /// logic checks needed to detect if a player has missed catching a fish
+            /// </summary>
             bool hasFailedCatch()
             {
                 return rod.timeUntilFishingNibbleDone < 0 && wasNibbling && !wasHit;

--- a/ButtplugValley/FishingRod.cs
+++ b/ButtplugValley/FishingRod.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+
+namespace ButtplugValley
+{
+    internal class FishingRod
+    {
+        private BPManager _bpManager;
+        private ModConfig modConfig;
+        private IModHelper helper;
+        private IMonitor monitor;
+        private bool isActive = true;
+        private float maxVibration = 100f; // Adjust as desired
+
+        public FishingRod(IModHelper modHelper, IMonitor MeMonitor, BPManager MEbpManager, ModConfig ModConfig)
+        {
+            helper = modHelper;
+            monitor = MeMonitor;
+            modConfig = ModConfig;
+            _bpManager = MEbpManager;
+            helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
+        }
+
+        private void OnUpdateTicked(object sender, UpdateTickedEventArgs e)
+        {
+            isActive = modConfig.VibrateOnFishingRodUsage;
+            if (!isActive) return;
+            if (Game1.player.CurrentTool is StardewValley.Tools.FishingRod rod)
+            {
+                if (!rod.isFishing) return;
+                monitor.Log("FishingRodIsActive", LogLevel.Debug);
+                maxVibration = modConfig.MaxFishingVibration;
+                Casting(rod);
+                Nibbling(rod);
+                Hit(rod);
+                Miss(rod);
+            }
+            
+        }
+
+        /// <summary>
+        /// Vibrate on casting and holding for power
+        /// </summary>
+        private void Casting(StardewValley.Tools.FishingRod rod)
+        {
+
+        }
+
+        /// <summary>
+        /// Tell user that fish is nibbling
+        /// </summary>
+        private void Nibbling(StardewValley.Tools.FishingRod rod)
+        {
+
+        }
+
+
+        /// <summary>
+        /// Inform user of successful hit
+        /// </summary>
+        private void Hit(StardewValley.Tools.FishingRod rod)
+        {
+
+        }
+
+        /// <summary>
+        /// Inform user of failed hit
+        /// </summary>
+        private void Miss(StardewValley.Tools.FishingRod rod)
+        {
+
+        }
+    }
+}

--- a/ButtplugValley/FishingRod.cs
+++ b/ButtplugValley/FishingRod.cs
@@ -88,17 +88,16 @@ namespace ButtplugValley
         /// <param name="ticks">time since start of game</param>
         private void Nibbling(StardewValley.Tools.FishingRod rod, uint ticks)
         {
-            if (!wasNibbling)
+            if (wasNibbling) return;
+
+            if (rod.isNibbling)
             {
-                if (rod.isNibbling)
-                {
-                    _ = _bpManager.VibrateDevicePulse(maxVibration * .8f);
-                    wasNibbling = true;
-                }
-                else if (ticks % 110 == 0)
-                {
-                    _ = _bpManager.VibrateDevicePulse(maxVibration * 0.1f, 200);
-                }
+                _ = _bpManager.VibrateDevicePulse(maxVibration * .8f);
+                wasNibbling = true;
+            }
+            else if (ticks % 110 == 0)
+            {
+                _ = _bpManager.VibrateDevicePulse(maxVibration * 0.1f, 200);
             }
         }
 

--- a/ButtplugValley/ModConfig.cs
+++ b/ButtplugValley/ModConfig.cs
@@ -17,7 +17,9 @@ namespace ButtplugValley
         public bool VibrateOnDayEnd { get; set; } = true;
         
         public bool VibrateOnFishingMinigame { get; set; } = true;
-        
+
+        public bool VibrateOnFishingRodUsage { get; set; } = true;
+
         public bool VibrateOnArcade { get; set; } = true;
         
         public bool VibrateOnDialogue { get; set; } = true;

--- a/ButtplugValley/ModEntry.cs
+++ b/ButtplugValley/ModEntry.cs
@@ -216,6 +216,13 @@ namespace ButtplugValley
             );
             configMenu.AddBoolOption(
                 mod: this.ModManifest,
+                name: () => "Fishing Rod",
+                tooltip: () => "Should the device vibrate when using fishing rod",
+                getValue: () => this.Config.VibrateOnFishingRodUsage,
+                setValue: value => this.Config.VibrateOnFishingRodUsage = value
+            );
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
                 name: () => "Arcade Minigames",
                 tooltip: () => "Should the device vibrate on certain events in the arcade minigames?",
                 getValue: () => this.Config.VibrateOnArcade,

--- a/ButtplugValley/ModEntry.cs
+++ b/ButtplugValley/ModEntry.cs
@@ -39,6 +39,7 @@ namespace ButtplugValley
             this.Config = this.Helper.ReadConfig<ModConfig>();
             buttplugManager = new BPManager();
             fishingMinigame = new FishingMinigame(helper, Monitor, buttplugManager);
+            new FishingRod(helper, Monitor, buttplugManager, Config);
             Task.Run(async () =>
             {
                 await buttplugManager.ConnectButtplug(Monitor, Config.IntifaceIP);


### PR DESCRIPTION
Added functionality to the use of the fishing rod before the minigame begins. Implements part of #3 
Features: 
- Vibrates based on the power level of the casting
- Little vibrations between the casting and hit to give the play something
- Big vibration on fish bite
- Fun little womp womp vibrations if they miss the fish hit window